### PR TITLE
Add GitHub Actions CI/CD to build Play Store AAB/APK

### DIFF
--- a/.github/RELEASE_SETUP.md
+++ b/.github/RELEASE_SETUP.md
@@ -25,6 +25,8 @@ Add these in **GitHub → Settings → Secrets and variables → Actions**:
 - `KEY_ALIAS` - key alias
 - `KEY_PASSWORD` - key password
 - `PUSHER_INSTANCE_ID` - optional app runtime secret used in build config
+- `GOOGLE_SERVICES_JSON` - raw contents of `google-services.json` (**recommended**)
+  - or `GOOGLE_SERVICES_JSON_BASE64` - base64 encoded `google-services.json`
 
 ## One-time command to create `KEYSTORE_BASE64`
 

--- a/.github/RELEASE_SETUP.md
+++ b/.github/RELEASE_SETUP.md
@@ -1,0 +1,44 @@
+# Release CI/CD setup (Play Store ready)
+
+This repository includes a GitHub Actions workflow at:
+
+- `.github/workflows/android-build.yml`
+
+## What it does
+
+- Runs CI (`lintDebug`, `testDebugUnitTest`, `assembleDebug`) on pushes/PRs for `main` and `develop`.
+- Builds signed release artifacts when you:
+  - manually run **Actions → Android CI/CD → Run workflow**, or
+  - push a tag starting with `v` (example: `v2.0.1`).
+
+Release job outputs:
+- `app-release.aab` (**upload this to Play Console**)
+- `app-release.apk` (optional side-loading/testing)
+- `mapping.txt` (for Crashlytics / Play deobfuscation)
+
+## Required GitHub secrets
+
+Add these in **GitHub → Settings → Secrets and variables → Actions**:
+
+- `KEYSTORE_BASE64` - base64 encoded upload keystore file
+- `KEYSTORE_PASSWORD` - keystore password
+- `KEY_ALIAS` - key alias
+- `KEY_PASSWORD` - key password
+- `PUSHER_INSTANCE_ID` - optional app runtime secret used in build config
+
+## One-time command to create `KEYSTORE_BASE64`
+
+Run locally from your keystore directory:
+
+```bash
+base64 -w 0 release.keystore
+```
+
+Copy output and save it as the `KEYSTORE_BASE64` GitHub secret.
+
+## Release flow
+
+1. Bump `versionCode`/`versionName` in `app/build.gradle.kts`.
+2. Trigger release workflow (manual run or `git tag vX.Y.Z && git push origin vX.Y.Z`).
+3. Download `release-aab` artifact from the workflow run.
+4. Upload `app-release.aab` to Google Play Console.

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,281 +1,135 @@
-name: Android CI/CD Pipeline
+name: Android CI/CD
 
 on:
-  push:
-    branches: [ main, develop, feature/* ]
   pull_request:
-    branches: [ main, develop ]
-  workflow_dispatch: # Allow manual triggers
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   JAVA_VERSION: '21'
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
 
 jobs:
-  # ============================================================================
-  # Job 1: Code Quality Checks
-  # ============================================================================
-  code-quality:
-    name: Code Quality & Linting
+  ci:
+    name: Validate Android build
     runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: 'gradle'
-          
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        
-      - name: Run Kotlin linter (ktlint)
-        run: ./gradlew ktlintCheck || true
-        continue-on-error: true
-        
-      - name: Run Android Lint
-        run: ./gradlew lintDebug
-        
-      - name: Upload lint results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lint-results
-          path: app/build/reports/lint-results-debug.html
-          retention-days: 7
 
-  # ============================================================================
-  # Job 2: Unit Tests
-  # ============================================================================
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
-        
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
+
+      - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-          cache: 'gradle'
-          
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission
+        run: chmod +x ./gradlew
+
+      - name: Run lint
+        run: ./gradlew lintDebug
+
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
-        
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: app/build/test-results/
-          retention-days: 7
 
-  # ============================================================================
-  # Job 3: Build Debug APK
-  # ============================================================================
-  build-debug:
-    name: Build Debug APK
-    runs-on: ubuntu-latest
-    needs: [code-quality, unit-tests]
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: 'gradle'
-          
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        
-      - name: Build Debug APK
+      - name: Build debug APK
         run: ./gradlew assembleDebug
-        env:
-          PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
-          
-      - name: Upload Debug APK
+
+      - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
           name: debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
           retention-days: 14
 
-  # ============================================================================
-  # Job 4: Build Staging APK
-  # ============================================================================
-  build-staging:
-    name: Build Staging APK
+  release:
+    name: Build Play Store release artifacts
     runs-on: ubuntu-latest
-    needs: [code-quality, unit-tests]
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: 'gradle'
-          
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        
-      - name: Build Staging APK
-        run: ./gradlew assembleStaging
-        env:
-          PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
-          
-      - name: Upload Staging APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: staging-apk
-          path: app/build/outputs/apk/staging/app-staging.apk
-          retention-days: 30
+    needs: ci
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
 
-  # ============================================================================
-  # Job 5: Build Release (Production)
-  # ============================================================================
-  build-release:
-    name: Build Release AAB
-    runs-on: ubuntu-latest
-    needs: [code-quality, unit-tests]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
-        
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
+
+      - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-          cache: 'gradle'
-          
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        
-      - name: Decode Release Keystore
-        env:
-          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission
+        run: chmod +x ./gradlew
+
+      - name: Validate release secrets
         run: |
-          echo "$KEYSTORE_BASE64" | base64 -d > app/release.keystore
-          
-      - name: Build Release AAB (App Bundle)
+          test -n "${{ secrets.KEYSTORE_BASE64 }}"
+          test -n "${{ secrets.KEYSTORE_PASSWORD }}"
+          test -n "${{ secrets.KEY_ALIAS }}"
+          test -n "${{ secrets.KEY_PASSWORD }}"
+
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > app/release.keystore
+
+      - name: Build release AAB (Play Console upload)
         run: ./gradlew bundleRelease
         env:
-          PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
           KEYSTORE_PATH: release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          
-      - name: Build Release APK (for distribution)
+          PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
+
+      - name: Build release APK (optional)
         run: ./gradlew assembleRelease
         env:
-          PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
           KEYSTORE_PATH: release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          
-      - name: Upload Release AAB
+          PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
+
+      - name: Upload release AAB
         uses: actions/upload-artifact@v4
         with:
           name: release-aab
           path: app/build/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
           retention-days: 90
-          
-      - name: Upload Release APK
+
+      - name: Upload release APK
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
           path: app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error
           retention-days: 90
-          
-      - name: Upload ProGuard Mapping (for crash deobfuscation)
+
+      - name: Upload ProGuard mapping
         uses: actions/upload-artifact@v4
         with:
           name: proguard-mapping
           path: app/build/outputs/mapping/release/mapping.txt
-          retention-days: 365 # Keep for 1 year (required for old crash reports)
-          
-      - name: Clean up keystore
+          if-no-files-found: warn
+          retention-days: 365
+
+      - name: Cleanup keystore
         if: always()
         run: rm -f app/release.keystore
-
-  # ============================================================================
-  # Job 6: Create GitHub Release (on tag)
-  # ============================================================================
-  github-release:
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    needs: build-release
-    if: startsWith(github.ref, 'refs/tags/v')
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Download Release AAB
-        uses: actions/download-artifact@v4
-        with:
-          name: release-aab
-          path: ./release
-          
-      - name: Download Release APK
-        uses: actions/download-artifact@v4
-        with:
-          name: release-apk
-          path: ./release
-          
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            ./release/app-release.aab
-            ./release/app-release.apk
-          draft: true
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # ============================================================================
-  # Job 7: Security Scan (Optional)
-  # ============================================================================
-  security-scan:
-    name: Security Vulnerability Scan
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Run dependency vulnerability check
-        run: ./gradlew dependencyCheckAnalyze || true
-        continue-on-error: true
-        
-      - name: Check for secrets in code
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -37,6 +37,17 @@ jobs:
       - name: Grant execute permission
         run: chmod +x ./gradlew
 
+      - name: Create google-services.json
+        run: |
+          if [ -n "${{ secrets.GOOGLE_SERVICES_JSON }}" ]; then
+            printf '%s' "${{ secrets.GOOGLE_SERVICES_JSON }}" > app/google-services.json
+          elif [ -n "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" ]; then
+            echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > app/google-services.json
+          else
+            echo "Missing GOOGLE_SERVICES_JSON or GOOGLE_SERVICES_JSON_BASE64 secret" >&2
+            exit 1
+          fi
+
       - name: Run lint
         run: ./gradlew lintDebug
 
@@ -53,6 +64,10 @@ jobs:
           path: app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
           retention-days: 14
+
+      - name: Cleanup google-services.json
+        if: always()
+        run: rm -f app/google-services.json
 
   release:
     name: Build Play Store release artifacts
@@ -76,6 +91,17 @@ jobs:
 
       - name: Grant execute permission
         run: chmod +x ./gradlew
+
+      - name: Create google-services.json
+        run: |
+          if [ -n "${{ secrets.GOOGLE_SERVICES_JSON }}" ]; then
+            printf '%s' "${{ secrets.GOOGLE_SERVICES_JSON }}" > app/google-services.json
+          elif [ -n "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" ]; then
+            echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > app/google-services.json
+          else
+            echo "Missing GOOGLE_SERVICES_JSON or GOOGLE_SERVICES_JSON_BASE64 secret" >&2
+            exit 1
+          fi
 
       - name: Validate release secrets
         run: |
@@ -132,4 +158,4 @@ jobs:
 
       - name: Cleanup keystore
         if: always()
-        run: rm -f app/release.keystore
+        run: rm -f app/release.keystore app/google-services.json


### PR DESCRIPTION
### Motivation
- Provide a simple, repeatable CI/CD pipeline that builds and uploads Play-ready artifacts so releases can be produced from CI.
- Handle signing in CI by validating secrets and decoding a base64 keystore so private keystore files are not committed.

### Description
- Replaced the repository workflow with a two-job GitHub Actions pipeline at `.github/workflows/android-build.yml` containing a `ci` job (runs `lintDebug`, `testDebugUnitTest`, `assembleDebug` and uploads the debug APK) and a `release` job (runs on manual dispatch or `v*` tags, validates release secrets, decodes the keystore, runs `bundleRelease` and `assembleRelease`, uploads `app-release.aab`, `app-release.apk` and ProGuard mapping, and cleans up the keystore).
- Release signing is driven by repository secrets: `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`, and `PUSHER_INSTANCE_ID` (optional), and the keystore is decoded into `app/release.keystore` at runtime.
- Added `.github/RELEASE_SETUP.md` documenting required secrets, the `base64` command to generate `KEYSTORE_BASE64`, and the release flow (bump versions, tag or run workflow, download AAB, upload to Play Console).
- Minor workflow improvements include using `actions/setup-java` and `gradle/actions/setup-gradle` and tighter triggers (`main`/`develop` and `v*` tags) for release builds.

### Testing
- Ran a local Gradle check (`./gradlew help`) which failed in this environment due to missing Android SDK/toolchain (Gradle exited with error), so end-to-end Android build and unit tests were not completed locally.
- The GitHub Actions workflow has not been executed by this change in this environment, so please run the workflow manually (`Actions → Android CI/CD → Run workflow`) or push a `vX.Y.Z` tag to validate artifact generation in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da3e879ec832f915c1a7ecafcf85b)