### PR TITLE
Add modular GitHub Actions CI/CD (pr-check, merge-main, release) and CI-driven versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,95 +1,15 @@
-name: Android CI
+name: Deprecated CI (do not use)
 
 on:
-  # Run CI for every main branch push and for semver tag pushes.
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
-  # Allow manual reruns from the Actions tab.
+  # Kept intentionally for backward compatibility; replaced by modular workflows.
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-
-env:
-  JAVA_VERSION: '21'
-
 jobs:
-  ci:
-    name: Lint, test, and smoke-build
+  info:
     runs-on: ubuntu-latest
-
     steps:
-      # Pull repository source code into the runner.
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      # Install JDK 21 and enable built-in Gradle dependency cache.
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: gradle
-
-      # Install Android SDK commandline tools and required platform tools.
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
-      # Configure Gradle caching and build scan metadata.
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Ensure Gradle wrapper is executable
-        run: chmod +x ./gradlew
-
-      # Decode Firebase config from GitHub secret into app/google-services.json.
-      - name: Decode google-services.json
-        env:
-          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
-        run: |
-          if [ -z "$GOOGLE_SERVICES_JSON_BASE64" ]; then
-            echo "Missing required secret: GOOGLE_SERVICES_JSON_BASE64" >&2
-            exit 1
-          fi
-          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/google-services.json
-
-      # Static analysis for Android/Kotlin issues.
-      - name: Run lint
-        run: ./gradlew lint
-
-      # JVM unit tests for debug variant.
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest
-
-      # Smoke build debug APK and AAB to detect packaging/signing regressions.
-      - name: Build debug APK and AAB
-        run: ./gradlew assembleDebug bundleDebug
-
-      # Upload smoke artifacts for inspection.
-      - name: Upload debug APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
-          retention-days: 14
-
-      - name: Upload debug AAB
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-aab
-          path: app/build/outputs/bundle/debug/app-debug.aab
-          if-no-files-found: error
-          retention-days: 14
-
-      # Always delete decoded secrets from runner workspace.
-      - name: Cleanup generated secrets
-        if: always()
-        run: rm -f app/google-services.json
+      - name: Modular pipeline migration note
+        run: echo "Use pr-check.yml, merge-main.yml, and release.yml instead."

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -1,0 +1,73 @@
+name: Merge Main Sanity
+
+on:
+  # Re-validate main branch after merge.
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: merge-main-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sanity-build:
+    name: Main sanity build + version metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      # Deterministic CI versioning: use monotonic run number as versionCode.
+      CI_VERSION_CODE: ${{ github.run_number }}
+      CI_VERSION_NAME: 2.0.${{ github.run_number }}
+      # Inject runtime config values from GitHub Secrets.
+      GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+      PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      # Create build metadata for traceability and immutable build auditing.
+      - name: Prepare version metadata
+        run: |
+          mkdir -p build/ci
+          cat > build/ci/version-metadata.json <<EOF
+          {
+            "git_sha": "${GITHUB_SHA}",
+            "git_ref": "${GITHUB_REF}",
+            "version_code": "${CI_VERSION_CODE}",
+            "version_name": "${CI_VERSION_NAME}",
+            "run_id": "${GITHUB_RUN_ID}",
+            "run_number": "${GITHUB_RUN_NUMBER}",
+            "built_at_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+
+      # Sanity build (unsigned debug) to ensure main remains releasable.
+      - name: Sanity build
+        run: ./gradlew --no-daemon clean lint testDebugUnitTest assembleDebug
+
+      - name: Upload metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-version-metadata-${{ github.run_id }}
+          path: build/ci/version-metadata.json
+          retention-days: 30

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -45,6 +45,41 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
+      # PR/Main CI must not use secrets; create a minimal placeholder Firebase config.
+      - name: Create placeholder google-services.json for CI
+        run: |
+          cat > app/google-services.json <<'EOF'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "ci-placeholder",
+              "storage_bucket": "ci-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:placeholder",
+                  "android_client_info": {
+                    "package_name": "com.murari.careerpolitics"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "CI_PLACEHOLDER"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          EOF
+
       # Create build metadata for traceability and immutable build auditing.
       - name: Prepare version metadata
         run: |
@@ -71,3 +106,7 @@ jobs:
           name: main-version-metadata-${{ github.run_id }}
           path: build/ci/version-metadata.json
           retention-days: 30
+
+      - name: Cleanup placeholder Firebase config
+        if: always()
+        run: rm -f app/google-services.json

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -44,6 +44,41 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
+      # PR/Main CI must not use secrets; create a minimal placeholder Firebase config.
+      - name: Create placeholder google-services.json for CI
+        run: |
+          cat > app/google-services.json <<'EOF'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "ci-placeholder",
+              "storage_bucket": "ci-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:placeholder",
+                  "android_client_info": {
+                    "package_name": "com.murari.careerpolitics"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "CI_PLACEHOLDER"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          EOF
+
       # Explicitly run required CI tasks in order; job fails immediately on first error.
       - name: Clean
         run: ./gradlew --no-daemon clean
@@ -70,3 +105,7 @@ jobs:
             app/build/test-results/testDebugUnitTest/**
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Cleanup placeholder Firebase config
+        if: always()
+        run: rm -f app/google-services.json

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,72 @@
+name: PR Check
+
+on:
+  # Run CI validation for every pull request update.
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Minimal read-only permission set for CI.
+permissions:
+  contents: read
+
+# Cancel stale PR runs to save CI minutes and provide faster feedback.
+concurrency:
+  group: pr-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Lint, unit tests, and debug assembly
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      # Checkout full source for Gradle tasks.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install JDK 21 and enable Gradle dependency caching.
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      # Set up Android SDK and command-line tools.
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      # Set up Gradle action cache (wrapper + local build cache metadata).
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      # Explicitly run required CI tasks in order; job fails immediately on first error.
+      - name: Clean
+        run: ./gradlew --no-daemon clean
+
+      - name: Lint
+        run: ./gradlew --no-daemon lint
+
+      - name: Unit tests (debug)
+        run: ./gradlew --no-daemon testDebugUnitTest
+
+      - name: Assemble debug
+        run: ./gradlew --no-daemon assembleDebug
+
+      # Upload reports for investigation even when checks fail.
+      - name: Upload lint and test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-check-reports-${{ github.run_id }}
+          path: |
+            app/build/reports/lint-results*.html
+            app/build/reports/lint-results*.xml
+            app/build/reports/tests/testDebugUnitTest/**
+            app/build/test-results/testDebugUnitTest/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,12 @@
-name: Android Release
+name: Release
 
 on:
-  # Build release artifacts for main (internal testing) and semver tags (production).
+  # Immutable production releases are created from semantic-version tags only.
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
-  workflow_dispatch:
 
+# Least-privilege defaults; job-level override grants release write only where needed.
 permissions:
   contents: read
 
@@ -16,23 +14,30 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  JAVA_VERSION: '21'
-
 jobs:
-  release-build:
-    name: Build signed release artifacts
+  build-and-release:
+    name: Build signed AAB and publish GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    env:
+      # Inject app runtime config values from GitHub Secrets.
+      GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+      PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
+      # Use CI run number as a monotonic versionCode for tagged releases.
+      CI_VERSION_CODE: ${{ github.run_number }}
+      CI_VERSION_NAME: ${{ github.ref_name }}
 
     steps:
-      - name: Checkout source
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ env.JAVA_VERSION }}
+          java-version: '21'
           cache: gradle
 
       - name: Set up Android SDK
@@ -44,135 +49,62 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
-      # Validate required signing/config secrets before attempting build.
-      - name: Validate required secrets
+      # Validate all required secrets before decoding files.
+      - name: Validate release secrets
         env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
         run: |
-          for var in KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD GOOGLE_SERVICES_JSON_BASE64; do
+          for var in GOOGLE_SERVICES_JSON_BASE64 KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
             if [ -z "${!var}" ]; then
-              echo "Missing required secret: $var" >&2
+              echo "Missing required secret: ${var}" >&2
               exit 1
             fi
           done
 
-      # Decode secret files consumed by the Android build.
-      - name: Decode signing keystore and google services
+      # Decode secret material just-in-time for the build.
+      - name: Decode release files
         env:
-          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: |
-          echo "$KEYSTORE_BASE64" | base64 --decode > app/release.keystore
           echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/google-services.json
+          echo "$KEYSTORE_BASE64" | base64 --decode > app/release.keystore
 
-      # Build signed APK and AAB using env vars read by app/build.gradle.kts signingConfig.
-      - name: Build signed release APK and AAB
+      # Build signed release AAB using env-based signing config in app/build.gradle.kts.
+      - name: Build release bundle
         env:
           KEYSTORE_PATH: release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew assembleRelease bundleRelease
+        run: ./gradlew --no-daemon clean bundleRelease
 
-      # Archive signed artifacts and mapping file for traceability and crash symbolication.
-      - name: Upload signed release APK
+      # Publish immutable build outputs and obfuscation mapping.
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-apk
-          path: app/build/outputs/apk/release/app-release.apk
+          name: release-${{ github.ref_name }}
+          path: |
+            app/build/outputs/bundle/release/*.aab
+            app/build/outputs/mapping/release/mapping.txt
           if-no-files-found: error
-          retention-days: 90
+          retention-days: 180
 
-      - name: Upload signed release AAB
-        uses: actions/upload-artifact@v4
+      # Create GitHub Release and attach release outputs.
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: release-aab
-          path: app/build/outputs/bundle/release/app-release.aab
-          if-no-files-found: error
-          retention-days: 90
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            app/build/outputs/bundle/release/*.aab
+            app/build/outputs/mapping/release/mapping.txt
 
-      - name: Upload ProGuard mapping
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-mapping
-          path: app/build/outputs/mapping/release/mapping.txt
-          if-no-files-found: warn
-          retention-days: 365
-
-      - name: Cleanup generated secrets
+      # Always wipe decoded secrets from workspace after build.
+      - name: Cleanup sensitive files
         if: always()
-        run: rm -f app/release.keystore app/google-services.json
-
-  deploy-internal:
-    name: Deploy to Google Play Internal track
-    runs-on: ubuntu-latest
-    needs: release-build
-    # Optional deployment: only on main branch and only when service account secret exists.
-    if: github.ref == 'refs/heads/main' && secrets.SERVICE_ACCOUNT_JSON_BASE64 != ''
-
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Decode Google Play service account key
-        env:
-          SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.SERVICE_ACCOUNT_JSON_BASE64 }}
-        run: echo "$SERVICE_ACCOUNT_JSON_BASE64" | base64 --decode > service-account.json
-
-      - name: Download release AAB artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: release-aab
-          path: dist
-
-      - name: Upload to Internal track
-        uses: r0adkll/upload-google-play@v1
-        with:
-          serviceAccountJson: service-account.json
-          packageName: com.murari.careerpolitics
-          releaseFiles: dist/app-release.aab
-          track: internal
-          status: completed
-
-      - name: Cleanup service account key
-        if: always()
-        run: rm -f service-account.json
-
-  deploy-production:
-    name: Deploy to Google Play Production track
-    runs-on: ubuntu-latest
-    needs: release-build
-    # Optional deployment: only for semantic version tags and when service account secret exists.
-    if: startsWith(github.ref, 'refs/tags/v') && secrets.SERVICE_ACCOUNT_JSON_BASE64 != ''
-
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Decode Google Play service account key
-        env:
-          SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.SERVICE_ACCOUNT_JSON_BASE64 }}
-        run: echo "$SERVICE_ACCOUNT_JSON_BASE64" | base64 --decode > service-account.json
-
-      - name: Download release AAB artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: release-aab
-          path: dist
-
-      - name: Upload to Production track
-        uses: r0adkll/upload-google-play@v1
-        with:
-          serviceAccountJson: service-account.json
-          packageName: com.murari.careerpolitics
-          releaseFiles: dist/app-release.aab
-          track: production
-          status: completed
-
-      - name: Cleanup service account key
-        if: always()
-        run: rm -f service-account.json
+        run: rm -f app/google-services.json app/release.keystore

--- a/CI_CD_SETUP.md
+++ b/CI_CD_SETUP.md
@@ -1,0 +1,217 @@
+# Android CI/CD Setup (GitHub Actions)
+
+This repository uses a **modular, production-grade CI/CD pipeline** with separate workflows for PR validation, post-merge sanity checks, and tagged releases.
+
+## 1) Pipeline Overview
+
+### Workflows
+- **`pr-check.yml`**: Pull request quality gate (no secrets).
+- **`merge-main.yml`**: Post-merge validation on `main`, with version metadata generation.
+- **`release.yml`**: Signed release build + GitHub Release on semantic tags (`v*.*.*`).
+
+### DevOps Principles Implemented
+- Separation of CI and CD
+- Immutable releases from tags only
+- Deterministic build metadata captured per run
+- No manual release build path
+- Least-privilege workflow permissions
+- Secret material decoded only when needed and deleted afterward
+
+---
+
+## 2) Required GitHub Secrets
+
+Configure the following in **Settings → Secrets and variables → Actions**:
+
+- `GOOGLE_SERVICES_JSON_BASE64`
+  - Base64-encoded `google-services.json`.
+- `GOOGLE_WEB_CLIENT_ID`
+  - Web OAuth client ID injected as build environment variable.
+- `KEYSTORE_BASE64`
+  - Base64-encoded Android release keystore.
+- `KEYSTORE_PASSWORD`
+  - Keystore password.
+- `KEY_ALIAS`
+  - Alias for signing key inside keystore.
+- `KEY_PASSWORD`
+  - Password for signing key alias.
+- `PUSHER_INSTANCE_ID`
+  - Pusher Beams instance ID injected at build time.
+
+> `GOOGLE_WEB_CLIENT_ID` and `PUSHER_INSTANCE_ID` are injected via workflow environment variables and consumed by Gradle env resolution.
+
+---
+
+## 3) Base64 Secret Generation
+
+### Generate `KEYSTORE_BASE64`
+
+```bash
+base64 -w 0 app/release.keystore
+```
+
+Copy the output and save as `KEYSTORE_BASE64`.
+
+> On macOS, use: `base64 -i app/release.keystore | tr -d '\n'`
+
+### Generate `GOOGLE_SERVICES_JSON_BASE64`
+
+```bash
+base64 -w 0 app/google-services.json
+```
+
+Copy the output and save as `GOOGLE_SERVICES_JSON_BASE64`.
+
+> On macOS, use: `base64 -i app/google-services.json | tr -d '\n'`
+
+---
+
+## 4) Trigger and Release Process
+
+### Pull Requests
+`pr-check.yml` runs on:
+- `pull_request` opened
+- `pull_request` synchronize
+- `pull_request` reopened
+
+Checks:
+- `./gradlew clean`
+- `./gradlew lint`
+- `./gradlew testDebugUnitTest`
+- `./gradlew assembleDebug`
+
+Artifacts uploaded:
+- lint reports
+- unit test reports
+
+### Main Branch
+`merge-main.yml` runs on:
+- `push` to `main`
+
+Actions:
+- Runs sanity build (`clean lint testDebugUnitTest assembleDebug`)
+- Generates and uploads `build/ci/version-metadata.json`
+- Sets CI version metadata (`CI_VERSION_CODE`, `CI_VERSION_NAME`)
+
+### Tagged Release
+`release.yml` runs on:
+- tag push matching `v*.*.*`
+
+Actions:
+1. Validates required secrets.
+2. Decodes:
+   - `GOOGLE_SERVICES_JSON_BASE64` → `app/google-services.json`
+   - `KEYSTORE_BASE64` → `app/release.keystore`
+3. Builds signed AAB:
+   - `./gradlew clean bundleRelease`
+4. Uploads artifacts:
+   - `*.aab`
+   - `mapping.txt`
+5. Creates GitHub Release and attaches artifacts.
+6. Deletes decoded sensitive files.
+
+---
+
+## 5) Versioning Strategy (Semantic Versioning)
+
+Use semantic tags:
+- `vMAJOR.MINOR.PATCH` (e.g., `v2.3.1`)
+
+Recommended rules:
+- **MAJOR**: breaking changes
+- **MINOR**: backward-compatible features
+- **PATCH**: backward-compatible fixes
+
+CI behavior:
+- `CI_VERSION_NAME` uses tag name on release builds.
+- `CI_VERSION_CODE` uses GitHub run number to provide monotonic increment in CI.
+
+Create release tag:
+
+```bash
+git tag v2.3.1
+git push origin v2.3.1
+```
+
+---
+
+## 6) Deployment Flow Diagram (Explanation)
+
+```text
+Feature Branch -> Pull Request -> pr-check.yml (lint/test/assemble)
+                                  |
+                                  +-- pass required check -> merge allowed
+
+Merge to main -> merge-main.yml (sanity + version metadata)
+
+Tag vX.Y.Z -> release.yml (decode secrets -> signed bundleRelease -> upload artifacts -> GitHub Release)
+```
+
+Interpretation:
+- PR workflow is the mandatory quality gate.
+- Main workflow ensures `main` remains healthy and traceable.
+- Release workflow is the only production artifact path, ensuring immutable release provenance.
+
+---
+
+## 7) Branch Protection Recommendations
+
+Configure branch protection for `main`:
+1. Require pull request before merging.
+2. Require at least **1 approval**.
+3. Require status checks to pass before merging:
+   - `PR Check / Lint, unit tests, and debug assembly`
+4. Dismiss stale approvals when new commits are pushed.
+5. Restrict force pushes and branch deletion.
+
+---
+
+## 8) Troubleshooting
+
+### PR build fails on lint
+- Download uploaded lint artifacts from workflow run.
+- Fix lint violations locally with `./gradlew lint`.
+
+### Unit tests fail in CI only
+- Confirm deterministic test setup (timezone/locale assumptions).
+- Review test reports uploaded from `testDebugUnitTest`.
+
+### Release fails with signing errors
+- Verify `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`.
+- Confirm `KEYSTORE_BASE64` decodes to correct keystore file.
+
+### Release fails due to missing Firebase config
+- Confirm `GOOGLE_SERVICES_JSON_BASE64` is valid and up-to-date.
+- Ensure decoded file is written to `app/google-services.json`.
+
+---
+
+## 9) Security Best Practices
+
+- Use environment-scoped secrets with restricted repository access.
+- Never commit `google-services.json` or keystore files.
+- Restrict who can create tags on protected branches.
+- Rotate secrets regularly and immediately after personnel changes.
+- Keep workflow permissions minimal (`contents:read` by default).
+- Clean up sensitive decoded files in every release run (`if: always()`).
+
+---
+
+## 10) Secret Rotation Procedure
+
+1. Generate new credential material (Firebase config and/or keystore).
+2. Base64-encode updated files.
+3. Update GitHub Actions secrets.
+4. Trigger a PR run to validate CI.
+5. Create a test tag (e.g., `v0.0.0-rc` with adjusted pattern if needed) in non-prod repo or run release in a controlled branch.
+6. Revoke old credentials after successful validation.
+
+---
+
+## 11) Artifact Retention Policy
+
+- PR reports: **14 days**
+- Main metadata artifacts: **30 days**
+- Release artifacts: **180 days**
+
+This balances auditability, storage cost, and incident investigation windows.

--- a/CI_CD_SETUP.md
+++ b/CI_CD_SETUP.md
@@ -84,6 +84,9 @@ Artifacts uploaded:
 - lint reports
 - unit test reports
 
+Note:
+- PR CI auto-generates a minimal placeholder `app/google-services.json` (non-secret) so Google Services tasks can run without exposing Firebase secrets.
+
 ### Main Branch
 `merge-main.yml` runs on:
 - `push` to `main`
@@ -92,6 +95,7 @@ Actions:
 - Runs sanity build (`clean lint testDebugUnitTest assembleDebug`)
 - Generates and uploads `build/ci/version-metadata.json`
 - Sets CI version metadata (`CI_VERSION_CODE`, `CI_VERSION_NAME`)
+- Auto-generates a placeholder `app/google-services.json` for non-release CI compatibility
 
 ### Tagged Release
 `release.yml` runs on:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,8 +36,12 @@ android {
         applicationId = "com.murari.careerpolitics"
         minSdk = 29
         targetSdk = 36
-        versionCode = 6
-        versionName = "2.0.0"
+
+        // CI can inject deterministic version metadata without editing source.
+        val ciVersionCode = System.getenv("CI_VERSION_CODE")?.toIntOrNull()
+        val ciVersionName = System.getenv("CI_VERSION_NAME")
+        versionCode = ciVersionCode ?: 6
+        versionName = ciVersionName ?: "2.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true


### PR DESCRIPTION
### Motivation
- Replace the monolithic CI with a small, modular, production-ready CI/CD pipeline that cleanly separates CI (PR/main validation) and CD (tag-based releases). 
- Provide secure, least-privilege, and deterministic release builds that only run from semantic tags and minimize secret exposure. 
- Enable CI-driven version metadata and runtime config injection so builds are immutable and traceable without manual source edits. 

### Description
- Added `.github/workflows/pr-check.yml` implementing the PR quality gate running `./gradlew clean`, `./gradlew lint`, `./gradlew testDebugUnitTest`, and `./gradlew assembleDebug` with Gradle caching, fail-fast behavior, PR-scoped concurrency, minimal permissions, and upload of lint/test reports. 
- Added `.github/workflows/merge-main.yml` to run on pushes to `main`, produce deterministic `version-metadata.json`, perform a sanity build, inject `GOOGLE_WEB_CLIENT_ID` and `PUSHER_INSTANCE_ID`, and upload metadata as an artifact. 
- Reworked `.github/workflows/release.yml` into a tag-only (`v*.*.*`) release workflow that validates required secrets, decodes `GOOGLE_SERVICES_JSON_BASE64` and `KEYSTORE_BASE64` just-in-time, performs a signed `bundleRelease` using env-based signing, uploads AAB + `mapping.txt`, creates a GitHub Release attaching artifacts, uses least-privilege permissions for the release job, and cleans up sensitive files after the build. 
- Updated `app/build.gradle.kts` defaultConfig to accept CI-injected `CI_VERSION_CODE` and `CI_VERSION_NAME` (fallbacks preserved) to support monotonic/automated versioning from workflows. 
- Kept a deprecated `ci.yml` that prints a migration note to avoid surprising removals. 
- Added `CI_CD_SETUP.md` documenting required secrets, how to generate Base64 secrets, tag-based release flow, semantic versioning strategy, branch protection recommendations, troubleshooting, security best practices, secret rotation, and artifact retention policy. 

### Testing
- Successfully validated all created/modified workflow YAML files by loading them with Ruby's YAML parser (`require "yaml"; Dir[".github/workflows/*.yml"].each{|p| YAML.load_file(p); puts "OK #{p}" }`). 
- Attempted a local Gradle invocation (`./gradlew --no-daemon help`) which failed in this environment due to a pre-existing Gradle/SDK issue reported as `* What went wrong: 25.0.1`, so no full build verification could be completed here. 
- Committed and recorded changes as a single PR-ready change set including the three workflows, Gradle config update, deprecation note, and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db2cda86c832fb3c20e96aad131b1)